### PR TITLE
Make the important methods public in Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! This library has a C interface as well as Python bindings. Currently, all
 //! methods return Pyo3's `PyResult`; in the future we plan to add a simplified
 //! return type for Rust-exclusive use.
-//! 
+//!
 //! Example
 //! ```rust
 //! use glider_api::{Mode, Rect, Display}
@@ -32,7 +32,6 @@ impl<T> ResultExt<T> for HidResult<T> {
     }
 }
 
-
 impl<T> ResultExt<T> for serialport::Result<T> {
     fn to_py_err(self) -> PyResult<T> {
         match self {
@@ -45,32 +44,32 @@ impl<T> ResultExt<T> for serialport::Result<T> {
 const VENDOR_ID: u16 = 0x0483;
 const PRODUCT_ID: u16 = 0x5750;
 
-/// Modes supported by the display controller. 
-/// 
+/// Modes supported by the display controller.
+///
 /// *ManualLUTNoDither*: 1-bit mode with a custom look-up-table (LUT). Note that
 /// this API does not support uploading manual LUTs at this time.
 ///
-/// *ManualLUTErrorDiffusion*: 1-bit mode with a custom look-up-table (LUT), 
-/// using error diffusion dithering to approximate grey values. Note that this 
+/// *ManualLUTErrorDiffusion*: 1-bit mode with a custom look-up-table (LUT),
+/// using error diffusion dithering to approximate grey values. Note that this
 /// API does not support uploading manual LUTs at this time.
 ///
-/// *FastMonoNoDither*: 1-bit mode. All gray values are converted to either 
+/// *FastMonoNoDither*: 1-bit mode. All gray values are converted to either
 /// black or white.
 ///
 /// *FastMonoBayer*: 1-bit mode with Bayer dithering.
 ///
-/// *FastMonoBlueNoise*: 1-bit mode with dithering based on a blue noise 
+/// *FastMonoBlueNoise*: 1-bit mode with dithering based on a blue noise
 /// pattern.
 ///
-/// *FastGrey*: Optimized 4-level grey mode. Note this mode has a much slower 
+/// *FastGrey*: Optimized 4-level grey mode. Note this mode has a much slower
 /// refresh rate compared to all other modes.
 ///
-/// *AutoNoDither*: Optimized display mode that switches between 1-bit and gray 
-/// values depending on the speed of update. When the input image is changed, it 
+/// *AutoNoDither*: Optimized display mode that switches between 1-bit and gray
+/// values depending on the speed of update. When the input image is changed, it
 /// switches to 1-bit mode with no dithering and does the update. When the image
 /// hasn’t changed for a while, it re-renders the image in greyscale.
 ///
-/// *AutoErrorDiffusion*: Like `AutoNoDither`, but uses error diffusion to 
+/// *AutoErrorDiffusion*: Like `AutoNoDither`, but uses error diffusion to
 /// approximate grey values during for image updates.
 #[repr(i16)]
 #[pyclass(eq, eq_int)]
@@ -80,8 +79,8 @@ pub enum Mode {
     /// not support uploading manual LUTs at this time.
     ManualLUTNoDither = 0,
 
-    /// 1-bit mode with a custom look-up-table (LUT), using error diffusion 
-    /// dithering to approximate grey values. Note that this API does not 
+    /// 1-bit mode with a custom look-up-table (LUT), using error diffusion
+    /// dithering to approximate grey values. Note that this API does not
     /// support uploading manual LUTs at this time.
     ManualLUTErrorDiffusion = 1,
 
@@ -94,13 +93,13 @@ pub enum Mode {
     /// 1-bit mode with dithering based on a blue noise pattern.
     FastMonoBlueNoise = 4,
 
-    /// Optimized 4-level grey mode. Note this mode has a much slower refresh 
+    /// Optimized 4-level grey mode. Note this mode has a much slower refresh
     /// rate compared to all other modes.
     FastGrey = 5,
 
     /// Optimized display mode that switches between 1-bit and gray values
-    /// depending on the speed of update. When the input image is changed, it 
-    /// switches to 1-bit mode with no dithering and does the update. When the 
+    /// depending on the speed of update. When the input image is changed, it
+    /// switches to 1-bit mode with no dithering and does the update. When the
     /// image hasn’t changed for a while, it re-renders the image in greyscale.
     AutoNoDither = 6,
 
@@ -125,8 +124,9 @@ pub struct Rect {
 
 #[pymethods]
 impl Rect {
+    /// Define a rectangular area from the four provided coordinates.
     #[new]
-    fn new(x0: i16, y0: i16, x1: i16, y1: i16) -> Self {
+    pub fn new(x0: i16, y0: i16, x1: i16, y1: i16) -> Self {
         Self { x0, y0, x1, y1 }
     }
 }
@@ -134,19 +134,20 @@ impl Rect {
 /// Core structure defining the display and possible interactions.
 #[pyclass(frozen)]
 pub struct Display {
-    device: HidDevice
+    device: HidDevice,
 }
 
 unsafe impl Send for Display {}
 unsafe impl Sync for Display {}
 
-
 #[pymethods]
 impl Display {
-
     /// Connects to the display and returns a `Display` struct for control.
+    ///
+    /// NOTE: This disables device discovery in the HidApi crate. If you are using another
+    /// that also uses HidApi, this may lead to conflicts.
     #[new]
-    fn new() -> PyResult<Self> {
+    pub fn new() -> PyResult<Self> {
         let api = HidApi::new_without_enumerate().to_py_err()?;
         let device = api.open(VENDOR_ID, PRODUCT_ID).to_py_err()?;
 
@@ -155,11 +156,11 @@ impl Display {
 
     /// Sets the mode for a region of the display. Note that this will always
     /// force a redraw of the region.
-    fn set_mode(&self, mode: &Mode, area: &Rect) -> PyResult<()> {
+    pub fn set_mode(&self, mode: &Mode, area: &Rect) -> PyResult<()> {
         let mut buf = BytesMut::with_capacity(16);
         buf.put_i16(USBCMD_SETMODE);
         buf.put_i16(mode.clone() as i16);
-        buf.put_u8(0x00); // WORKAROUND: Alignment is decoded incorrectly in fw. 
+        buf.put_u8(0x00); // WORKAROUND: Alignment is decoded incorrectly in fw.
         buf.put_i16_le(area.x0);
         buf.put_i16_le(area.y0);
         buf.put_i16_le(area.x1);
@@ -172,25 +173,25 @@ impl Display {
         match LittleEndian::read_u16(&response) {
             0x00 => Err(PyTypeError::new_err("invalid command")),
             0x01 => Err(PyTypeError::new_err("checksum incorrect")),
-            _ => Ok(())
+            _ => Ok(()),
         }
     }
 
     /// Force a redraw of the region. This will trigger a "flash" of the area
     /// from black to white before setting the image, in order to clear any
     /// ghosting.
-    fn redraw(&self, area: &Rect) -> PyResult<()> {
+    pub fn redraw(&self, area: &Rect) -> PyResult<()> {
         let mut buf = BytesMut::with_capacity(16);
 
         buf.put_i16(USBCMD_REDRAW);
         buf.put_i16(0x0000); // Dummy param value
-        buf.put_u8(0x00); // WORKAROUND: Alignment is decoded incorrectly in fw. 
+        buf.put_u8(0x00); // WORKAROUND: Alignment is decoded incorrectly in fw.
         buf.put_i16_le(area.x0);
         buf.put_i16_le(area.y0);
         buf.put_i16_le(area.x1);
         buf.put_i16_le(area.y1);
-                 
-        let chksum= crc16::State::<crc16::XMODEM>::calculate(&buf);
+
+        let chksum = crc16::State::<crc16::XMODEM>::calculate(&buf);
         buf.put_u16(chksum);
         self.device.write(&buf).to_py_err()?;
 
@@ -199,9 +200,9 @@ impl Display {
         match LittleEndian::read_u16(&response) {
             0x00 => Err(PyTypeError::new_err("invalid command")),
             0x01 => Err(PyTypeError::new_err("checksum incorrect")),
-            _ => Ok(())
+            _ => Ok(()),
         }
-    }  
+    }
 }
 
 // C API


### PR DESCRIPTION
Without the `pub` keyword, the Rust SDK is pretty useless. Check `cargo doc`: the only documented methods on `Display` and `Rect` are the Python bindings.

Make the SDK useful to Rust programmers: make the important methods public.